### PR TITLE
feat: make https web server optional with cli parameter

### DIFF
--- a/galene.go
+++ b/galene.go
@@ -24,6 +24,8 @@ func main() {
 		"web server root `directory`")
 	flag.StringVar(&webserver.Redirect, "redirect", "",
 		"redirect to canonical `host`")
+	flag.BoolVar(&webserver.UseHttps, "https", true,
+		"web server https using cert.pem and key.pem from data directory")
 	flag.StringVar(&dataDir, "data", "./data/",
 		"data `directory`")
 	flag.StringVar(&group.Directory, "groups", "./groups/",

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -33,6 +33,8 @@ var StaticRoot string
 
 var Redirect string
 
+var UseHttps bool
+
 func Serve(address string, dataDir string) error {
 	http.Handle("/", &fileHandler{http.Dir(StaticRoot)})
 	http.HandleFunc("/group/", groupHandler)
@@ -68,10 +70,17 @@ func Serve(address string, dataDir string) error {
 
 	server.Store(s)
 
-	err := s.ListenAndServeTLS(
-		filepath.Join(dataDir, "cert.pem"),
-		filepath.Join(dataDir, "key.pem"),
-	)
+	var err error
+
+	if UseHttps {
+		err = s.ListenAndServeTLS(
+			filepath.Join(dataDir, "cert.pem"),
+			filepath.Join(dataDir, "key.pem"),
+		)
+	} else {
+		err = s.ListenAndServe()
+	}
+
 	if err == http.ErrServerClosed {
 		return nil
 	}


### PR DESCRIPTION
This adds a parameter to galene to make https optional. I figured that the default mode should be true, since that is now the default as well. To force galene to http:
```
./galene --https=false
```