### PR TITLE
GitHub actions

### DIFF
--- a/.github/linters/.stylelintrc.json
+++ b/.github/linters/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "stylelint-config-standard",
+    "rules": {
+        "indentation": 4
+    }
+}

--- a/.github/workflows/galene.yml
+++ b/.github/workflows/galene.yml
@@ -1,0 +1,111 @@
+name: Galène
+on: [push, pull_request]
+jobs:
+  # Build and test Galène on three boring systems
+  native-build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
+        go: [ 1.13, 1.16 ]
+    name: Galène, Golang ${{ matrix.go }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Set Windows env vars
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          "GOMODCACHE=$(go env GOMODCACHE)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "GOCACHE=$(go env GOCACHE)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Set UNIX env vars
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          printf "GOMODCACHE=%s\n" $(go env GOMODCACHE) >> $GITHUB_ENV
+          printf "GOCACHE=%s\n" $(go env GOCACHE) >> $GITHUB_ENV
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+      - name: Build
+        env:
+          CGO_ENABLED: 0
+        run: go build -ldflags='-s -w' ./...
+      - name: Test
+        run: go test -short ./...
+
+  # Cross-compile Galène for a selection of architectures
+  x-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [ 1.13, 1.16 ]
+        goarch: [ mips, mipsle, mips64, mips64le, arm64]
+        include:
+          - goarch: mips
+            gomips: softfloat
+    name: Galène, cross-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Set UNIX env vars
+        run: |
+          printf "GOMODCACHE=%s\n" $(go env GOMODCACHE) >> $GITHUB_ENV
+          printf "GOCACHE=%s\n" $(go env GOCACHE) >> $GITHUB_ENV
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+      - name: Build
+        env:
+          CGO_ENABLED: 0
+          GOOS: linux
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+          GOMIPS: ${{ matrix.gomips }}
+        run: go build -ldflags='-s -w' ./...
+
+  # It's just easier to duplicate the steps for arm
+  x-build-arm:
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [ 1.13, 1.16 ]
+        goarm: [ 5, 6, 7 ]
+    name: Galène, cross-build arm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Set UNIX env vars
+        run: |
+          printf "GOMODCACHE=%s\n" $(go env GOMODCACHE) >> $GITHUB_ENV
+          printf "GOCACHE=%s\n" $(go env GOCACHE) >> $GITHUB_ENV
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+      - name: Build
+        env:
+          CGO_ENABLED: 0
+          GOOS: linux
+          GOARCH: arm
+          GOARM: ${{ matrix.goarm }}
+        run: go build -ldflags='-s -w' ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,30 @@
+name: golangci-lint
+on: [push, pull_request]
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,7 @@ jobs:
           VALIDATE_CSS: true
           VALIDATE_GO: false    # Golang is currently broken with super-linter
           VALIDATE_HTML: true
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           FILTER_REGEX_EXCLUDE: static/(css|scripts|webfonts)/.*
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,21 @@
+name: Lint Galène
+on: [push, pull_request]
+jobs:
+  build:
+    name: Lint Galène
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Lint Galène
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_CSS: true
+          VALIDATE_GO: false    # Golang is currently broken with super-linter
+          VALIDATE_HTML: true
+          VALIDATE_ALL_CODEBASE: false
+          FILTER_REGEX_EXCLUDE: static/(css|scripts|webfonts)/.*
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/rtptime/rtptime_test.go
+++ b/rtptime/rtptime_test.go
@@ -25,6 +25,9 @@ func differs(a, b, delta uint64) bool {
 }
 
 func TestTime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping TestTime in short mode")
+	}
 	a := Now(48000)
 	time.Sleep(40 * time.Millisecond)
 	b := Now(48000) - a


### PR DESCRIPTION
Ah, I wanted to test that locally and opened the PR against the wrong
branch, but it should be correct nonetheless.

Seeing the recent talks on the mailing list and the 0.3.2 incident, I
revived my patches that provide continuous integration for Galène
using GitHub Actions. They’re simple: the script `galene.yml` hooks on
pushes and pull requests, builds and tests Galène on {Linux, macOS,
Windows} × Go {1.13, 1.16}, and also cross-builds Galène for a variety
of configurations (but we cannot execute tests on them).

Only GitHub-supported scripts are used for the best integration, and I
made sure to cache things properly to get the fastest feedback.

The other scripts are linters for Go, HTML, and CSS code. If you tell
me how exactly you use typescript/javascript in your workflow I can
add it too.

If you find the linters too noisy, it’s also possible to disable them
on pushes and use linters only during pull requests. That would help
with the quality of contributions, and not disturb the current
workflow.

It’s also possible to build binaries of Galène for each release, and
attach them automatically to the GitHub release page. I haven’t
experimented with that, I was wondering if you’d be interested, and
how we’d bundle the static assets (alongside the binary, or
embedded?). If you’re interested, please let me know, and the list of
systems to build for too.

I’ll show how it’ll look like for new contributors in a moment.

-- Antonin