### PR TITLE
Set of fixes for mainpage layout

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -11,7 +11,7 @@ h1 {
     padding-top: 0;
     border-width: thin;
     clear: both;
-    height: 3.125rem;
+    min-height: 3.125rem;
     text-align: center;
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -8,9 +8,6 @@
     <link rel="stylesheet" href="/mainpage.css">
     <link rel="stylesheet" type="text/css" href="/galene.css"/>
     <link rel="author" href="https://www.irif.fr/~jch/"/>
-    <!-- Font Awesome File -->
-    <link href="/css/fontawesome.min.css" rel="stylesheet" type="text/css">
-    <link href="/css/solid.css" rel="stylesheet" type="text/css">
   </head>
 
   <body>

--- a/static/mainpage.css
+++ b/static/mainpage.css
@@ -1,3 +1,9 @@
+body {
+    /* Used to move footer at bottom of the page */
+    display: flex;
+    flex-direction: column;
+}
+
 .groups {
 }
 
@@ -10,7 +16,7 @@
 }
 
 .home {
-  height: calc(100vh - 50px);
+  margin-bottom: auto;
   padding: 1.875rem;
 }
 


### PR DESCRIPTION
These commits fix the overflow on the main page, remove the CSS height `calc()` and remove font awesome.

Do we also want to center the `groupform` and `public-groups` table in the middle of the page? Example of render:

![Render example on medium size device](https://user-images.githubusercontent.com/2663216/113260234-4d232800-92ce-11eb-8d7f-8f64baf8538d.png)
