### PR TITLE
Make login box height automatic

### DIFF
--- a/static/galene.css
+++ b/static/galene.css
@@ -570,7 +570,6 @@ textarea.form-reply {
     width: 20em;
     padding: 1em;
     margin: 5em auto;
-    height: 23em;
     background: #fcfcfc;
 }
 


### PR DESCRIPTION
Do not hardcore login box height so its height can change depending on the content. Using "margin: auto" garantee that the box will be vertically and horizontally centered.

I have seen some instances of Galène where the admin changed the content of the login box. This patch makes the login box look great when content is added or removed inside.