### PR TITLE
Add vim mode lines to README files to get GitHub rendering the files as markdown files

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,4 @@
+<!-- vim: syntax=Markdown -->
 # Installation
 
 ## Build the `galene` binary

--- a/README.FRONTEND
+++ b/README.FRONTEND
@@ -1,3 +1,4 @@
+<!-- vim: syntax=Markdown -->
 # Writing a new frontend
 
 The frontend is written in JavaScript and is split into two files:

--- a/README.PROTOCOL
+++ b/README.PROTOCOL
@@ -1,3 +1,4 @@
+<!-- vim: syntax=Markdown -->
 # Galène's protocol
 
 Galène uses a symmetric, asynchronous protocol.  In client-server


### PR DESCRIPTION
Since jech doesn't like renaming README files with a .md extension just to keep GitHub happy, this might be a compromise to keep the original filenames but still enabling markdown rendering.