### PR TITLE
Add example nginx reverse proxy config file

### DIFF
--- a/example_config/nginx_reverse_proxy.conf
+++ b/example_config/nginx_reverse_proxy.conf
@@ -1,0 +1,37 @@
+server {
+  listen 80;
+  listen 443 ssl;
+  server_name YOUR_DOMAIN_NAME;
+
+  ssl_certificate /etc/letsencrypt/live/YOUR_DOMAIN_NAME/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/YOUR_DOMAIN_NAME/privkey.pem;
+
+  ssl_session_cache    shared:SSL:1m;
+  ssl_session_timeout  5m;
+
+  ssl_ciphers  HIGH:!aNULL:!MD5;
+  ssl_prefer_server_ciphers  on;
+
+  # Force usage of https
+  if ($scheme = http) {
+      rewrite ^ https://$server_name$request_uri? permanent;
+  }
+  # reverse proxy
+  location / {
+      proxy_pass https://localhost:8443;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Host $server_name;
+  }
+  # WebSocket support
+  location /ws {
+      proxy_pass https://localhost:8443;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade"; 
+      proxy_set_header Host $host;
+  }
+}


### PR DESCRIPTION
Hello,
I configured nginx as a reverse proxy to make galene reachable from the standard https port.
Besides, it makes letsencrypt certificates generation and renewal more convenient, as nginx is handled by certs handling tools.
It could be useful to add it to the main repository, as this config is not trivial.