### PR TITLE
WIP: Add media failed animation

### DIFF
--- a/static/galene.css
+++ b/static/galene.css
@@ -889,6 +889,7 @@ h1 {
 
 .media-failed {
     opacity: 0.7;
+    background: no-repeat center/50% 50% url("/media-failed.svg");
 }
 
 .mirror {

--- a/static/media-failed.svg
+++ b/static/media-failed.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 64 16" xmlns="http://www.w3.org/2000/svg">
+    <g fill="#ececec">
+        <circle cx="8" cy="8" r="8"/>
+        <circle cx="32" cy="8" r="8"/>
+        <circle cx="56" cy="8" r="8"/>
+    </g>
+    <style>
+    circle {
+      animation: circleScale 1.5s infinite ease-in-out;
+      transform-origin: 8px 8px;
+    }
+    circle:nth-child(2) {
+      animation-delay: -1s;
+      transform-origin: 32px 8px;
+    }
+    circle:nth-child(3) {
+      animation-delay: -0.5s;
+      transform-origin: 56px 8px;
+    }
+    @keyframes circleScale {
+      0%, 80%, 100% { transform: scale(0.8); }
+      40% { transform: scale(1.0); }
+    }
+    </style>
+</svg>


### PR DESCRIPTION
Proposal for https://github.com/jech/galene/issues/87.

Some notes:

- I propose to put the animation inside a SVG element to make it easier to tweak in the future. This also prevent the need for more HTML elements.
- This PR is not working as the loading animation is put in background (behind the video stream). To put an image on top of a video, it seems that we need to add another element as `<video>` does not seem to support `::before` CSS modifier.

Is it problematic if we add an element next to `<video>` to place this animation?