### PR TITLE
Fix typos

### DIFF
--- a/README
+++ b/README
@@ -194,7 +194,7 @@ The definition for the group called *groupname* is in the file
 `groups/groupname.json`; it does not contain the group name, which makes
 it easy to copy or link group definitions.  You may use subdirectories:
 a file `groups/teaching/networking.json` defines a group called
-*teching/networking*.
+*teaching/networking*.
 
 Every group definition file contains a JSON directory.  All fields are
 optional, but unless you specify at least one user definition (`op`,

--- a/README.PROTOCOL
+++ b/README.PROTOCOL
@@ -89,8 +89,8 @@ The `join` message requests that the sender join or leave a group:
 ```
 
 When the sender has effectively joined the group, the peer will send
-a 'joined' message of kind 'join'; it may then send a 'joined' message of
-kind 'change' at any time, in order to inform the client of a change in
+a `joined` message of kind `join`; it may then send a `joined` message of
+kind `change` at any time, in order to inform the client of a change in
 its permissions or in the recommended RTC configuration.
 
 ```javascript
@@ -135,8 +135,8 @@ A peer must explicitly request the streams that it wants to receive.
 ```
 
 The field `request` is a dictionary that maps the labels of requested
-streams to a list containing either 'audio', or one of 'video' or
-'video-low'.  The empty key `''` serves as default.  For example:
+streams to a list containing either `audio`, or one of `video` or
+`video-low`.  The empty key `''` serves as default.  For example:
 
 ```javascript
 {
@@ -146,6 +146,7 @@ streams to a list containing either 'audio', or one of 'video' or
         '': ['audio', 'video']
     }
 }
+```
 
 ## Pushing streams
 
@@ -159,11 +160,11 @@ A stream is created by the sender with the `offer` message:
     replace: id,
     source: source-id,
     username: username,
-    sdp: sdp,
+    sdp: sdp
 }
 ```
 
-If a stream with the same id exists, then this is a renegotation;
+If a stream with the same id exists, then this is a renegotiation;
 otherwise this message creates a new stream.  If the field `replace` is
 not empty, then this request additionally requests that an existing stream
 with the given id should be closed, and the new stream should replace it;
@@ -178,8 +179,8 @@ a JSEP session description).  Galène will interpret the `nack`,
 accordingly.
 
 The sender may either send a single stream per media section in the SDP,
-or use rid-based simulcasting.  In the latter case, it should send two
-video streams, one with rid 'h' and high throughput, and one with rid 'l'
+or use _rid-based_ simulcasting.  In the latter case, it should send two
+video streams, one with _rid_ `h` and high throughput, and one with _rid_ `l`
 and throughput limited to roughly 100kbit/s.
 
 The receiver may either abort the stream immediately (see below), or send
@@ -214,10 +215,11 @@ restart by sending a `renegotiate` message:
 ```
 
 At any time after answering, the client may change the set of streams
-being offered by sending a 'requestStream' request:
+being offered by sending a `requestStream` request:
+
 ```javascript
 {
-    type: 'answerStream'
+    type: 'requestStream'
     id: id,
     request: [audio, video]
 }

--- a/group/group_test.go
+++ b/group/group_test.go
@@ -55,7 +55,7 @@ func TestGroup(t *testing.T) {
 	}
 
 	if public := GetPublic(); len(public) != 1 || public[0].Name != "group/subgroup" {
-		t.Errorf("Expeced group/subgroup, got %v", public)
+		t.Errorf("Expected group/subgroup, got %v", public)
 	}
 
 	Expire()


### PR DESCRIPTION
This commit fixes some typos, and switches to inline code blocks some message types that were only quoted, for consistency.