### PR TITLE
Fix and simplify /help command

### DIFF
--- a/static/galene.js
+++ b/static/galene.js
@@ -2400,7 +2400,7 @@ function addToChatbox(peerId, dest, nick, time, privileged, history, kind, messa
  * @param {string} message
  */
 function localMessage(message) {
-    return addToChatbox(null, null, null, Date.now(), false, null, message);
+    return addToChatbox(null, null, null, Date.now(), false, false, '', message);
 }
 
 function clearChat() {
@@ -2857,6 +2857,7 @@ function handleInput() {
                 try {
                     c.f(cmd, rest);
                 } catch(e) {
+                    console.error(e);
                     displayError(e);
                 }
                 return;

--- a/static/galene.js
+++ b/static/galene.js
@@ -2455,11 +2455,7 @@ commands.help = {
                 continue;
             cs.push(`/${cmd}${c.parameters?' ' + c.parameters:''}: ${c.description}`);
         }
-        cs.sort();
-        let s = '';
-        for(let i = 0; i < cs.length; i++)
-            s = s + cs[i] + '\n';
-        localMessage(s);
+        localMessage(cs.sort().join('\n'));
     }
 };
 


### PR DESCRIPTION
It currently crashes with a TypeError as a new parameter was added. Dynamically-typed languages never forgive.