### PR TITLE
Make (un)present button width dynamic

### DIFF
--- a/static/galene.css
+++ b/static/galene.css
@@ -750,7 +750,6 @@ h1 {
     margin-top: .1em;
     font-size: 1.1em;
     text-align: left;
-    width: 5.8em;
 }
 
 #videoselect {


### PR DESCRIPTION
The present and unpresent button width is fixed to 5.8em. This is problematic as the content might need more space. By removing the width attribute, the element takes the width it requires.

![image](https://user-images.githubusercontent.com/2663216/131224989-11f16571-8b34-4a61-99dd-6abb7ad5c0d4.png)
Screenshot before the modification: "Disable" is overflowing to the right the button.