### PR TITLE
Fix #108

### DIFF
--- a/static/galene.css
+++ b/static/galene.css
@@ -48,10 +48,6 @@
     background-color: #eee;
 }
 
-.profile {
-    width: 230px;
-}
-
 .profile-logo {
     float: left;
     width: 50px;
@@ -992,7 +988,7 @@ h1 {
     padding: 10px;
     background: #fff;
     height: calc(100% - 56px);
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: hidden;
 }
 


### PR DESCRIPTION
Change for .sidenav-content overflow-y : auto instead of scroll (line 995) is a no-brainer, no side effect.

About removing .profile rule line 51 : I can't see the use of fixing the width for .profile to 230px. It seems to be ok to remove this rule.