### PR TITLE
Allow scroll bars in input form.

### DIFF
--- a/static/galene.css
+++ b/static/galene.css
@@ -851,7 +851,7 @@ h1 {
     width: 100%;
     border: none;
     resize: none;
-    overflow-y: hidden;
+    overflow-y: auto;
 }
 
 #input:focus {


### PR DESCRIPTION
@takdj, users are complaining that there's no feedback when copy-pasting multi-line text into Galene.  The simple solution is the attached, but perhaps it would be better to have the form expand up to 4 lines or so, and only add the scrollbars when the text doesn't fit in four lines?

Please let me know what you think.