### PR TITLE
frontend: add support for showing raised hand

### DIFF
--- a/static/galene.css
+++ b/static/galene.css
@@ -1204,6 +1204,10 @@ header .collapse {
     font-weight: 900;
 }
 
+#users > div.user-status-raisehand::before {
+    content: "\f256";
+}
+
 .close-icon {
     font: normal 1em/1 Arial, sans-serif;
     display: inline-block;

--- a/static/galene.js
+++ b/static/galene.js
@@ -1999,13 +1999,17 @@ function addUser(id, name) {
  * @param {string} id
  * @param {string} name
  */
-function changeUser(id, name) {
+function changeUser(id, userinfo) {
     let user = document.getElementById('user-' + id);
     if(!user) {
         console.warn('Unknown user ' + id);
         return;
     }
-    user.textContent = name ? name : '(anon)';
+    user.textContent = userinfo.username ? userinfo.username : '(anon)';
+    if (userinfo.status.raisehand)
+        user.classList.add('user-status-raisehand');
+    else
+        user.classList.remove('user-status-raisehand');
 }
 
 /**
@@ -2034,7 +2038,7 @@ function gotUser(id, kind) {
             scheduleReconsiderParameters();
         break;
     case 'change':
-        changeUser(id, serverConnection.users[id].username);
+        changeUser(id, serverConnection.users[id]);
         break;
     default:
         console.warn('Unknown user kind', kind);


### PR DESCRIPTION
We were puzzled that the `/raise` / `/unraise` commands had no effect and figured out the frontend simply ignores the `raisehand` status. This MR adds support for showing the `hand-paper` symbol (looks like a raised hand) instead of the `circle` symbol in the user list whenever a user raises their hand.

Is there any test for the frontend code that I should adjust?