### PR TITLE
Update required Go version in INSTALL to 1.16

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,7 +2,7 @@
 
 ## Build the `galene` binary
 
-You will need Go 1.13 or later (type `go version`).  Then do:
+You will need Go 1.16 or later (type `go version`).  Then do:
 
     CGO_ENABLED=0 go build -ldflags='-s -w'
 


### PR DESCRIPTION
Galene explicitely depends on Go >= 1.16 since 19a27003224591aca041855e9402ec32cae15886. This updates the instructions in INSTALL accordingly.