### PR TITLE
Autofocus forms on index and login pages

### DIFF
--- a/static/galene.js
+++ b/static/galene.js
@@ -3540,6 +3540,7 @@ async function start() {
     } else {
         let container = document.getElementById("login-container");
         container.classList.remove('invisible');
+        document.getElementById('username').focus()
     }
     setViewportHeight();
 }

--- a/static/index.html
+++ b/static/index.html
@@ -17,7 +17,7 @@
 
       <form id="groupform">
         <label for="group">Group:</label>
-        <input id="group" type="text" name="group" class="form-control form-control-inline"/>
+        <input id="group" type="text" name="group" class="form-control form-control-inline" autofocus/>
         <input id='submitbutton' type="submit" value="Join" class="btn btn-default btn-large"/><br/>
       </form>
 


### PR DESCRIPTION
This pull request proposes to:
- automatically focus the group field (index.html)
- automatically focus the username field (galene.html)

This makes the navigation a bit faster for people that are using only their keyboard.

One downside is that it might confuse screen readers if some content is skipped before the autofocused element. In this situation, I believe this souldn't be an issue.