### PR TITLE
Add Referrer-Policy and X-Content-Type-Options headers

### DIFF
--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -103,6 +103,12 @@ func cspHeader(w http.ResponseWriter, connect string) {
 	}
 	w.Header().Add("Content-Security-Policy",
 		c+" img-src data: 'self'; media-src blob: 'self'; default-src 'self'")
+
+	// Make browser stop sending referrer information
+	w.Header().Add("Referrer-Policy", "no-referrer")
+
+	// Require correct MIME type to load CSS and JS
+	w.Header().Add("X-Content-Type-Options", "nosniff")
 }
 
 func notFound(w http.ResponseWriter) {


### PR DESCRIPTION
This pull request proposes to set:

- `Referrer-Policy` HTTP header to `no-referrer`. As Galène JavaScript code does not user referrer information, I believe it makes sense to disable it for privacy reasons.
- `X-Content-Type-Options` to `nosniff` to ensure that browsers load CSS and JS only if the MIME type is correct. This may protect against some types of XSS attacks.

I have put this code inside `cspHeader` function as it seems to make sense there, but maybe the function should be renamed `securityHeaders`.