### PR TITLE
Fix audio activity detection for downstreams

### DIFF
--- a/static/galene.js
+++ b/static/galene.js
@@ -767,7 +767,7 @@ function gotDownStats(stats) {
     c.pc.getReceivers().forEach(r => {
         let tid = r.track && r.track.id;
         let s = tid && stats[tid];
-        let energy = s && s['track'] && s['track'].audioEnergy;
+        let energy = s && s['inbound-rtp'] && s['inbound-rtp'].audioEnergy;
         if(typeof energy === 'number')
             maxEnergy = Math.max(maxEnergy, energy);
     });

--- a/static/protocol.js
+++ b/static/protocol.js
@@ -1466,7 +1466,7 @@ Stream.prototype.updateStats = async function() {
 
         if(report) {
             for(let r of report.values()) {
-                if(rtid && r.type === 'track') {
+                if(rtid && r.type === 'inbound-rtp') {
                     if(!('totalAudioEnergy' in r))
                         continue;
                     if(!stats[rtid])


### PR DESCRIPTION
Changes:
- Replaced the non-existent `track` property in `RTCStatsType` with the valid `inbound-rtp` property.
- This change rectifies the audio activity detection for downstream audio tracks.

Relevant documentations:
  - `RTCStatsType`: [Link](https://w3c.github.io/webrtc-stats/#rtctatstype-*)
  - `RTCInboundRTPStreamStats`: [Link](https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats)

#168 