### PR TITLE
Set start time, end time and warning time of the end of the meeting

### DIFF
--- a/README
+++ b/README
@@ -172,6 +172,12 @@ nobody will be able to join the group.  The following fields are allowed:
    to the given URL; most other fields are ignored in this case;
  - `codecs`: this is a list of codecs allowed in this group.  The default
    is `["vp8", "opus"]`.
+- `meeting-start` : set the starting date-time of a meeting in "YYYY-MM-DD H:i:s" format, e.g. "2024-02-25 15:00:00";
+   no user will be able to login before the starting time
+- `meeting-end` : set the end date-time of a meeting in "YYYY-MM-DD H:i:s" format, e.g. "2024-02-25 17:00:00";
+   at this time all users will be kicked out.
+- `meeting-end-warning` : set the time in minutes when all users will be warned that the meeting will end in x minutes, e.g. 10.
+   If no value is provided and a meeting-end is set, users will receive a warning 10 minutes ahead of the end of the meeting
    
 Supported video codecs include:
 

--- a/group/description.go
+++ b/group/description.go
@@ -40,6 +40,15 @@ type Description struct {
 	// other fields are ignored.
 	Redirect string `json:"redirect,omitempty"`
 
+	// Set the start of the meeting. format: YYYY-MM-DD HH:mm:ss
+	MeetingStart string `json:"meeting-start,omitempty"`
+
+	// Set the end of the meeting. format: YYYY-MM-DD HH:mm:ss
+	MeetingEnd string `json:"meeting-end,omitempty"`
+
+	// Set a end of the meeting in minutes, integer
+	WarningBeforeEnd int `json:"meeting-end-warning,omitempty"`
+
 	// The maximum number of simultaneous clients.  Unlimited if 0.
 	MaxClients int `json:"max-clients,omitempty"`
 

--- a/rtpconn/webclient.go
+++ b/rtpconn/webclient.go
@@ -1007,6 +1007,8 @@ func clientLoop(c *webClient, ws *websocket.Conn, versionError bool) error {
 			// seconds, make sure we generate some activity
 			// after 55s at most.
 			if time.Since(readTime) > 45*time.Second {
+				// meeting expiry
+		       		go c.group.MeetingEnds()
 				err := c.write(clientMessage{
 					Type: "ping",
 				})


### PR DESCRIPTION
Hello,

i've added an optional start time and end time for meetings in "YYYY-MM-DD hh:mm:ss" format which can be added to the *.json files of the groups.
Added also an optional value to set the time in minutes when all users will receive a warning that the meeting will end soon (Meeting will end in x minutes).
No idea if it's perfect but it works, it was my first time coding in go.
Added also a description in of the values in the README file.




