### PR TITLE
LibreJS support

### DIFF
--- a/static/404.html
+++ b/static/404.html
@@ -25,6 +25,6 @@
         <a href="/" class="home-link">Back to home</a>
       </div>
     </div>
-    <a href="/javascript" rel="jslicense">JavaScript license information</a>
+    <a href="/javascript.html" rel="jslicense">JavaScript license information</a>
   </body>
 </html>

--- a/static/404.html
+++ b/static/404.html
@@ -13,18 +13,18 @@
   </head>
 
   <body>
-  
+
     <div class="wrapper">
       <div class="landing-page">
         <div class="logo">
           <i class="fas fa-frown" aria-hidden="true"></i>
         </div>
-        
-        <h1> Page not found!</h1>
-        <p> We can't find the page you're looking for.</p>
+
+        <h1>Page not found!</h1>
+        <p>We can't find the page you're looking for.</p>
         <a href="/" class="home-link">Back to home</a>
       </div>
     </div>
-    
+    <a href="/javascript" rel="jslicense">JavaScript license information</a>
   </body>
 </html>

--- a/static/change-password.html
+++ b/static/change-password.html
@@ -30,6 +30,6 @@
 
     <script src="/change-password.js" defer></script>
 
-    <p><a href="/javascript" rel="jslicense">JavaScript license information</a></p>
+    <p><a href="/javascript.html" rel="jslicense">JavaScript license information</a></p>
   </body>
 </html>

--- a/static/change-password.html
+++ b/static/change-password.html
@@ -29,5 +29,7 @@
     <p id="errormessage"></p>
 
     <script src="/change-password.js" defer></script>
+
+    <p><a href="/javascript" rel="jslicense">JavaScript license information</a></p>
   </body>
 </html>

--- a/static/galene.html
+++ b/static/galene.html
@@ -249,7 +249,7 @@
             <label for="displayallbox">Display audio-only users</label>
           </form>
         </fieldset>
-	<p><a href="/javascript" rel="jslicense">JavaScript license information</a></p>
+	<p><a href="/javascript.html" rel="jslicense">JavaScript license information</a></p>
       </div>
     </div>
 

--- a/static/galene.html
+++ b/static/galene.html
@@ -170,7 +170,7 @@
             <select id="videoselect" class="select select-inline">
               <option value="">off</option>
             </select>
-  
+
             <label for="audioselect" class="sidenav-label">Microphone:</label>
             <select id="audioselect" class="select select-inline">
               <option value="">off</option>
@@ -185,7 +185,7 @@
               <input id="blackboardbox" type="checkbox"/>
               <label for="blackboardbox">Blackboard mode</label>
             </form>
-  
+
             <form>
               <input id="preprocessingbox" type="checkbox"/ checked>
               <label for="preprocessingbox">Noise suppression</label>
@@ -238,7 +238,7 @@
               <option value="everything" selected>everything</option>
             </select>
           </form>
-  
+
           <form>
             <input id="activitybox" type="checkbox"/>
             <label for="activitybox">Activity detection</label>
@@ -249,6 +249,7 @@
             <label for="displayallbox">Display audio-only users</label>
           </form>
         </fieldset>
+	<p><a href="/javascript" rel="jslicense">JavaScript license information</a></p>
       </div>
     </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
       </div>
     </div>
     <footer class="signature">
-      <p><a href="https://galene.org/">Galène</a> by <a href="https://www.irif.fr/~jch/" rel="author">Juliusz Chroboczek</a> - <a href="/javascript" rel="jslicense">JavaScript license information</a></p>
+      <p><a href="https://galene.org/">Galène</a> by <a href="https://www.irif.fr/~jch/" rel="author">Juliusz Chroboczek</a> - <a href="/javascript.html" rel="jslicense">JavaScript license information</a></p>
     </footer>
     <script src="/mainpage.js" defer></script>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -9,9 +9,7 @@
     <link rel="stylesheet" type="text/css" href="/galene.css"/>
     <link rel="author" href="https://www.irif.fr/~jch/"/>
   </head>
-
   <body>
-  
     <div class="home">
       <h1 id="title" class="navbar-brand">Galène</h1>
 
@@ -22,20 +20,14 @@
       </form>
 
       <p id="errormessage"></p>
-  
       <div id="public-groups" class="groups">
         <h2>Public groups</h2>
-  
         <table id="public-groups-table"></table>
       </div>
     </div>
     <footer class="signature">
-      <p><a href="https://galene.org/">Galène</a> by <a href="https://www.irif.fr/~jch/" rel="author">Juliusz Chroboczek</a></p>
+      <p><a href="https://galene.org/">Galène</a> by <a href="https://www.irif.fr/~jch/" rel="author">Juliusz Chroboczek</a> - <a href="/javascript" rel="jslicense">JavaScript license information</a></p>
     </footer>
-    
     <script src="/mainpage.js" defer></script>
-    
   </body>
 </html>
-    
-  

--- a/static/javascript
+++ b/static/javascript
@@ -1,37 +1,47 @@
-<table id="jslicense-labels1">
-    <tr>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>JavaScript License Information</title>
+  </head>
+  <body>
+    <table id="jslicense-labels1">
+      <tr>
         <td><a href="/mainpage.js">mainpage.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
         <td><a href="/mainpage.js">mainpage.js</a></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td><a href="/protocol.js">protocol.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
         <td><a href="/protocol.js">protocol.js</a></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td><a href="/external/toastify/toastify.js">toastify.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
         <td><a href="/external/toastify/toastify.js">toastify.js</a></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td><a href="/external/contextual/contextual.js">contextual.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
         <td><a href="/external/contextual/contextual.js">contextual.js</a></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td><a href="/galene.js">galene.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
         <td><a href="/galene.js">galene.js</a></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td><a href="/stats.js">stats.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
         <td><a href="/stats.js">stats.js</a></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td><a href="/change-password.js">change-password.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
         <td><a href="/change-password.js">change-password.js</a></td>
-    </tr>
-</table>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/static/javascript
+++ b/static/javascript
@@ -1,0 +1,37 @@
+<table id="jslicense-labels1">
+    <tr>
+        <td><a href="https://galene.fsf.org/mainpage.js">mainpage.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="https://galene.fsf.org/mainpage.js">mainpage.js</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://galene.fsf.org/protocol.js">protocol.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="https://galene.fsf.org/protocol.js">protocol.js</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://galene.fsf.org/external/toastify/toastify.js">toastify.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="https://galene.fsf.org/external/toastify/toastify.js">toastify.js</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://galene.fsf.org/external/contextual/contextual.js">contextual.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="https://galene.fsf.org/external/contextual/contextual.js">contextual.js</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://galene.fsf.org/galene.js">galene.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="https://galene.fsf.org/galene.js">galene.js</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://galene.fsf.org/stats.js">stats.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="https://galene.fsf.org/stats.js">stats.js</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://galene.fsf.org/change-password.js">change-password.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="https://galene.fsf.org/change-password.js">change-password.js</a></td>
+    </tr>
+</table>

--- a/static/javascript
+++ b/static/javascript
@@ -1,37 +1,37 @@
 <table id="jslicense-labels1">
     <tr>
-        <td><a href="https://galene.fsf.org/mainpage.js">mainpage.js</a></td>
+        <td><a href="/mainpage.js">mainpage.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-        <td><a href="https://galene.fsf.org/mainpage.js">mainpage.js</a></td>
+        <td><a href="/mainpage.js">mainpage.js</a></td>
     </tr>
     <tr>
-        <td><a href="https://galene.fsf.org/protocol.js">protocol.js</a></td>
+        <td><a href="/protocol.js">protocol.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-        <td><a href="https://galene.fsf.org/protocol.js">protocol.js</a></td>
+        <td><a href="/protocol.js">protocol.js</a></td>
     </tr>
     <tr>
-        <td><a href="https://galene.fsf.org/external/toastify/toastify.js">toastify.js</a></td>
+        <td><a href="/external/toastify/toastify.js">toastify.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-        <td><a href="https://galene.fsf.org/external/toastify/toastify.js">toastify.js</a></td>
+        <td><a href="/external/toastify/toastify.js">toastify.js</a></td>
     </tr>
     <tr>
-        <td><a href="https://galene.fsf.org/external/contextual/contextual.js">contextual.js</a></td>
+        <td><a href="/external/contextual/contextual.js">contextual.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-        <td><a href="https://galene.fsf.org/external/contextual/contextual.js">contextual.js</a></td>
+        <td><a href="/external/contextual/contextual.js">contextual.js</a></td>
     </tr>
     <tr>
-        <td><a href="https://galene.fsf.org/galene.js">galene.js</a></td>
+        <td><a href="/galene.js">galene.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-        <td><a href="https://galene.fsf.org/galene.js">galene.js</a></td>
+        <td><a href="/galene.js">galene.js</a></td>
     </tr>
     <tr>
-        <td><a href="https://galene.fsf.org/stats.js">stats.js</a></td>
+        <td><a href="/stats.js">stats.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-        <td><a href="https://galene.fsf.org/stats.js">stats.js</a></td>
+        <td><a href="/stats.js">stats.js</a></td>
     </tr>
     <tr>
-        <td><a href="https://galene.fsf.org/change-password.js">change-password.js</a></td>
+        <td><a href="/change-password.js">change-password.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-        <td><a href="https://galene.fsf.org/change-password.js">change-password.js</a></td>
+        <td><a href="/change-password.js">change-password.js</a></td>
     </tr>
 </table>

--- a/static/javascript.html
+++ b/static/javascript.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta charset="utf-8">
     <title>JavaScript License Information</title>
   </head>
   <body>

--- a/static/stats.html
+++ b/static/stats.html
@@ -7,11 +7,10 @@
     <link rel="stylesheet" href="/common.css">
     <link rel="author" href="https://www.irif.fr/~jch/"/>
   </head>
-
   <body>
-  
     <h1 id="title" class="navbar-brand">Galène statistics</h1>
     <table id="stats-table"></table>
     <script src="/stats.js" defer></script>
+    <a href="/javascript" rel="jslicense">JavaScript license information</a>
   </body>
 </html>

--- a/static/stats.html
+++ b/static/stats.html
@@ -11,6 +11,6 @@
     <h1 id="title" class="navbar-brand">Galène statistics</h1>
     <table id="stats-table"></table>
     <script src="/stats.js" defer></script>
-    <a href="/javascript" rel="jslicense">JavaScript license information</a>
+    <a href="/javascript.html" rel="jslicense">JavaScript license information</a>
   </body>
 </html>


### PR DESCRIPTION
This is a patch that adds [LibreJS](https://www.gnu.org/software/librejs/) support to Galène. I followed section 3.1 of the [LibreJS doc](https://www.gnu.org/software/librejs/free-your-javascript.html) using the weblabels method. For all that are not using LibreJS, there is no change except for an additional link with JavaScript licensing information.

I was not really sure where to put the link in `galene.html` so I put it at the bottom of the settings menu.

I also removed some stray spaces.

If any additional .js files are added, I can maintain the `javascript` file in the future.