### PR TITLE
Don't unmute until camera/microphone are enabled

### DIFF
--- a/static/galene.js
+++ b/static/galene.js
@@ -621,8 +621,12 @@ getInputElement('hqaudiobox').onchange = function(e) {
 document.getElementById('mutebutton').onclick = function(e) {
     e.preventDefault();
     let localMute = getSettings().localMute;
-    localMute = !localMute;
-    setLocalMute(localMute, true);
+    if (localMute && !findUpMedia('camera')) {
+        displayMessage('Please use Enable to enable your camera or microphone.');
+    } else {
+        localMute = !localMute;
+        setLocalMute(localMute, true);
+    }
 };
 
 document.getElementById('sharebutton').onclick = function(e) {


### PR DESCRIPTION
When I first used Galene, I started by not enabling my camera/microphone because I was mostly planning to stay silent, and then I got confused why muting/unmuting didn't work. That's probably more of a user error than anything, but I thought it might be useful to have a little message that reminds people to enable devices before unmuting instead of muting/unmuting with no effect. I'm new to the codebase and there's probably a much better way of doing this. What do you think of this patch?