### PR TITLE
Validate the right username

### DIFF
--- a/group/group.go
+++ b/group/group.go
@@ -1029,11 +1029,6 @@ func validUsername(username string) bool {
 
 // called locked
 func (g *Group) getPermission(creds ClientCredentials) (string, []string, error) {
-	if creds.Username != nil && !validUsername(*creds.Username) {
-		return "", nil, &NotAuthorisedError{
-			errors.New("invalid username"),
-		}
-	}
 	desc := g.description
 	var username string
 	var perms []string
@@ -1068,6 +1063,12 @@ func (g *Group) getPermission(creds ClientCredentials) (string, []string, error)
 		perms = ps.Permissions(desc)
 	} else {
 		return "", nil, errors.New("neither username nor token provided")
+	}
+
+	if !validUsername(username) {
+		return "", nil, &NotAuthorisedError{
+			errors.New("invalid username"),
+		}
 	}
 
 	return username, perms, nil


### PR DESCRIPTION
3ad12b6 added username validation, but only validated the username provided as part of the join event. When joining with an external token, the username needs to be loaded from the token instead.

This broke in two ways:
- in the default UI, the username would be passed in as "" with token auth, which failed validation even if the token was valid
- you could pass in a valid username in the join event, and then pass in an invalid one in the token, and that would be accepted and used, presumably allowing for the same shenanigans 3ad12b6 sought to prevent

Move username validation to the end, where we know what the right username is.