### PR TITLE
Various installation documentation fixes

### DIFF
--- a/galene-install.md
+++ b/galene-install.md
@@ -118,6 +118,26 @@ User=galene
 Group=galene
 ExecStart=/home/galene/galene
 LimitNOFILE=65536
+# hardening
+DeviceAllow=
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+RemoveIPC=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I had the chance to set up Galene on a brand new Debian server. Here is the patchset containing minor fixes to the installation documentation. Please feel free to cherry-pick what you like.

The last commit includes a bit of systemd hardening to motivate users using systemd to harden a bit more Galene. A subset of these hardening options are already by default in some distributions of Galene (such as OpenSUSE, NixOS).
The hardening has been left incomplete to keep the installation intuitive. An admin wanting to improve hardening might want to move Galene data to `/var/lib/galene/` and activate `ProtectHome`, `ProtectSystem` and configure `ReadWritePaths`.