### PR TITLE
Improve the nginx websocket proxy example

### DIFF
--- a/galene-install.md
+++ b/galene-install.md
@@ -264,9 +264,10 @@ example, with Nginx, you will need to say something like the following:
 
 ```
 location /ws {
-    proxy_pass ...;
+    proxy_pass https://localhost:8443/ws;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $http_host;
 }
 ```
 


### PR DESCRIPTION
Include the full `proxy-pass` directive (continuing the example) and set the `Host` header.

Issue #175 Websocket upgrade: websocket: request origin not allowed by
    Upgrader.CheckOrigin