### PR TITLE
Fix minor HTML errors

### DIFF
--- a/static/galene.html
+++ b/static/galene.html
@@ -192,7 +192,7 @@
             </form>
   
             <form>
-              <input id="preprocessingbox" type="checkbox"/ checked>
+              <input id="preprocessingbox" type="checkbox" checked/>
               <label for="preprocessingbox">Noise suppression</label>
             </form>
 
@@ -299,7 +299,7 @@
         <input id="invite-expires" type="datetime-local"/>
         <br>
         <button id="invite-cancel" value="cancel" type="button">Cancel</button>
-        <button value="invite" value="invite">Invite</button>
+        <button value="invite">Invite</button>
       </form>
     </dialog>
 


### PR DESCRIPTION
This PR fixes 2 minor errors I've noticed in the `static/galene.html` file:

- Misplaced slash
- Duplicate `value` attribute

@jech btw, is there a specific reason to have all the present [trailing slashes](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing) in void-elements? In HTML5 they are neither necessary nor harmful. But perhaps removing them will improve readability?