### PR TITLE
fix: allow wildcard password update when users map is nil

### DIFF
--- a/group/description.go
+++ b/group/description.go
@@ -761,9 +761,6 @@ func SetUserPassword(group, username string, wildcard bool, pw Password) error {
 	if err != nil {
 		return err
 	}
-	if desc.Users == nil {
-		return os.ErrNotExist
-	}
 
 	if wildcard {
 		if desc.WildcardUser == nil {
@@ -771,6 +768,9 @@ func SetUserPassword(group, username string, wildcard bool, pw Password) error {
 		}
 		desc.WildcardUser.Password = pw
 	} else {
+		if desc.Users == nil {
+			return os.ErrNotExist
+		}
 		user, ok := desc.Users[username]
 		if !ok {
 			return os.ErrNotExist


### PR DESCRIPTION
this should fix #306 .
At the moment ther's a workaround:

- create a temporary user
- set the wildcard password
- delete the temporary user

```bash
galenectl -insecure create-user -group test -user tmp
galenectl -insecure set-password -group test -wildcard -type wildcard
galenectl -insecure delete-user -group test -user tmp
```