### PR TITLE
Improve accessibility for screen reader users

### DIFF
--- a/rtpconn/webclient.go
+++ b/rtpconn/webclient.go
@@ -1906,7 +1906,7 @@ func handleClientMessage(c *webClient, m clientMessage) error {
 			}
 			t := g.GetClient(m.Dest)
 			if t == nil {
-				return c.error(group.UserError("no suck user"))
+				return c.error(group.UserError("no such user"))
 			}
 			target, ok := t.(*webClient)
 			if !ok {

--- a/static/galene.css
+++ b/static/galene.css
@@ -1,3 +1,27 @@
+/* Accessibility: Visible focus indicators for keyboard navigation */
+button:focus,
+[role="button"]:focus,
+select:focus,
+input:focus,
+textarea:focus,
+a:focus {
+    outline: 2px solid #0066cc;
+    outline-offset: 2px;
+}
+
+/* Accessibility: Screen reader only content */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
 .nav-fixed .topnav {
     z-index: 1039;
 }
@@ -312,7 +336,6 @@
     resize: none;
     overflow: hidden;
     padding: 5px;
-    outline: none;
     border: none;
     text-indent: 5px;
     box-shadow: none;
@@ -865,11 +888,13 @@ h1 {
 }
 
 #input:focus {
-    outline: none;
+    outline: 2px solid #0066cc;
+    outline-offset: 2px;
 }
 
 #inputbutton:focus {
-    outline: none;
+    outline: 2px solid #0066cc;
+    outline-offset: 2px;
 }
 
 #resizer {

--- a/static/galene.css
+++ b/static/galene.css
@@ -133,15 +133,18 @@ a:focus {
     display: none;
 }
 
-.sidenav .user-logout a {
+.sidenav .user-logout button {
+    background: transparent;
+    border: 0;
     font-size: 1em;
     padding: 7px 0 0;
     color: #e4157e;
     cursor: pointer;
+    font: inherit;
     line-height: .7;
 }
 
-.sidenav .user-logout a:hover {
+.sidenav .user-logout button:hover {
     color: #ab0659;
 }
 

--- a/static/galene.html
+++ b/static/galene.html
@@ -165,10 +165,10 @@
               <span id="chpwspan" class="invisible"><a id="change-password" aria-label="Change password">Change password</a></span>
             </div>
             <div class="user-logout">
-              <a id="disconnectbutton" aria-label="Logout">
+              <button id="disconnectbutton" type="button" aria-label="Logout">
                 <span class="logout-icon"><i class="fas fa-sign-out-alt" aria-hidden="true"></i></span>
                 <span class="logout-text">Logout</span>
-              </a>
+              </button>
             </div>
           </div>
         </div>

--- a/static/galene.html
+++ b/static/galene.html
@@ -29,9 +29,9 @@
           <header>
             <nav class="topnav navbar navbar-expand navbar-light fixed-top">
               <div id="header">
-                <div class="collapse" title="Collapse left panel" id="sidebarCollapse">
+                <button class="collapse" aria-label="Collapse left panel" id="sidebarCollapse">
                   <i class="fas fa-align-left" aria-hidden="true"></i>
-                </div>
+                </button>
                 <h1 id="title" class="header-title">Galène</h1>
               </div>
 
@@ -47,21 +47,21 @@
                   </button>
                 </li>
                 <li>
-                  <div id="mutebutton" class="nav-link nav-button">
+                  <button id="mutebutton" class="nav-link nav-button" aria-pressed="false" aria-label="Mute microphone">
                     <span><i class="fas fa-microphone-slash" aria-hidden="true"></i></span>
-                    <label>Mute</label>
-                  </div>
+                    <span class="nav-text">Mute</span>
+                  </button>
                 </li>
                 <li>
-                  <div id="sharebutton" class="invisible nav-link nav-button">
+                  <button id="sharebutton" class="invisible nav-link nav-button" aria-label="Share screen">
                     <span><i class="fas fa-share-square" aria-hidden="true"></i></span>
-                    <label>Share Screen</label>
-                  </div>
+                    <span class="nav-text">Share Screen</span>
+                  </button>
                 </li>
                 <li>
-                  <div class="nav-button nav-link nav-more" id="openside">
+                  <button class="nav-button nav-link nav-more" id="openside" aria-label="More options" aria-haspopup="true">
                     <span><i class="fas fa-ellipsis-v" aria-hidden="true"></i></span>
-                  </div>
+                  </button>
                 </li>
               </ul>
             </nav>
@@ -70,10 +70,11 @@
             <div class="coln-left" id="left">
               <div id="chat">
                 <div id="chatbox">
-                  <div class="close-chat" id="close-chat"  title="Hide chat">
+                  <button class="close-chat" id="close-chat" aria-label="Hide chat">
                     <span class="close-icon"></span>
-                  </div>
+                  </button>
                   <div id="box"></div>
+                  <div id="chat-announcements" aria-live="polite" aria-atomic="true" class="sr-only"></div>
                   <div class="reply">
                     <form id="inputform">
                       <textarea id="input" class="form-reply"></textarea>

--- a/static/galene.html
+++ b/static/galene.html
@@ -29,7 +29,7 @@
           <header>
             <nav class="topnav navbar navbar-expand navbar-light fixed-top">
               <div id="header">
-                <button class="collapse" aria-label="Collapse left panel" id="sidebarCollapse">
+                <button class="collapse" aria-label="Toggle left panel" aria-expanded="true" id="sidebarCollapse">
                   <i class="fas fa-align-left" aria-hidden="true"></i>
                 </button>
                 <h1 id="title" class="header-title">Galène</h1>
@@ -73,6 +73,7 @@
                   <button class="close-chat" id="close-chat" aria-label="Hide chat">
                     <span class="close-icon"></span>
                   </button>
+                  <h2 id="chat-history-heading" class="sr-only">Chat History</h2>
                   <div id="box"></div>
                   <div id="chat-announcements" aria-live="polite" aria-atomic="true" class="sr-only"></div>
                   <div class="reply">
@@ -116,21 +117,23 @@
                       <input id="password" type="password" name="password"
                              autocomplete="current-password" class="form-control"/>
                     </div>
-                    <label>Enable at start:</label>
-                    <div class="present-switch">
-                      <p class="switch-radio">
-                        <input id="presentoff" type="radio" name="presentradio" value="" checked/>
-                        <label for="presentoff">Nothing</label>
-                      </p>
-                      <p class="switch-radio">
-                        <input id="presentmike" type="radio" name="presentradio" value="mike"/>
-                        <label for="presentmike">Microphone</label>
-                      </p>
-                      <p class="switch-radio">
-                        <input id="presentboth" type="radio" name="presentradio" value="both"/>
-                        <label for="presentboth">Camera and microphone</label>
-                      </p>
-                    </div>
+                    <fieldset>
+                      <legend>Enable at start:</legend>
+                      <div class="present-switch">
+                        <p class="switch-radio">
+                          <input id="presentoff" type="radio" name="presentradio" value="" checked/>
+                          <label for="presentoff">Nothing</label>
+                        </p>
+                        <p class="switch-radio">
+                          <input id="presentmike" type="radio" name="presentradio" value="mike"/>
+                          <label for="presentmike">Microphone</label>
+                        </p>
+                        <p class="switch-radio">
+                          <input id="presentboth" type="radio" name="presentradio" value="both"/>
+                          <label for="presentboth">Camera and microphone</label>
+                        </p>
+                      </div>
+                    </fieldset>
                     <div class="clear"></div>
                     <div class="connect">
                       <input id="connectbutton" type="submit" class="btn btn-blue" value="Connect"/>
@@ -159,11 +162,11 @@
             <div class="profile-info">
               <span id="userspan"></span>
               <span id="permspan"></span>
-              <span id="chpwspan" class="invisible"><a id="change-password">Change password</a></span>
+              <span id="chpwspan" class="invisible"><a id="change-password" aria-label="Change password">Change password</a></span>
             </div>
             <div class="user-logout">
-              <a id="disconnectbutton">
-                <span class="logout-icon"><i class="fas fa-sign-out-alt"></i></span>
+              <a id="disconnectbutton" aria-label="Logout">
+                <span class="logout-icon"><i class="fas fa-sign-out-alt" aria-hidden="true"></i></span>
                 <span class="logout-text">Logout</span>
               </a>
             </div>

--- a/static/galene.html
+++ b/static/galene.html
@@ -84,7 +84,7 @@
                 </div>
               </div>
             </div>
-            <div id="resizer"></div>
+            <div id="resizer" tabindex="0" role="separator" aria-label="Chat resize handle" aria-orientation="vertical"></div>
             <div class="coln-right" id="right">
               <button class="show-video blink invisible" id="show-video" aria-label="Show video">
                 <i class="fas fa-exchange-alt" aria-hidden="true"></i>

--- a/static/galene.html
+++ b/static/galene.html
@@ -16,7 +16,7 @@
   </head>
 
   <body>
-    <div id="main" class="app">
+    <main id="main" class="app">
       <div class="row full-height">
         <nav id="left-sidebar">
           <div class="users-header">
@@ -68,7 +68,7 @@
           </header>
           <div class="row full-width" id="mainrow">
             <div class="coln-left" id="left">
-              <div id="chat">
+              <div id="chat" role="region" aria-label="Chat">
                 <div id="chatbox">
                   <button class="close-chat" id="close-chat" aria-label="Hide chat">
                     <span class="close-icon"></span>
@@ -78,7 +78,7 @@
                   <div class="reply">
                     <form id="inputform">
                       <textarea id="input" class="form-reply"></textarea>
-                      <input id="inputbutton" type="submit" value="&#10148;" class="btn btn-default"/>
+                      <input id="inputbutton" type="submit" value="&#10148;" class="btn btn-default" aria-label="Send message"/>
                     </form>
                   </div>
                 </div>
@@ -86,15 +86,15 @@
             </div>
             <div id="resizer"></div>
             <div class="coln-right" id="right">
-              <span class="show-video blink invisible" id="show-video">
+              <button class="show-video blink invisible" id="show-video" aria-label="Show video">
                 <i class="fas fa-exchange-alt" aria-hidden="true"></i>
-              </span>
-              <div class="chat-btn show-chat invisible" id="show-chat">
-                <i class="far fa-comment-alt icon-chat" title="Show chat"></i>
-              </div>
-              <div class="chat-btn collapse-video invisible" id="collapse-video">
-                <i class="far fa-comment-alt icon-chat" title="Hide video and show chat"></i>
-              </div>
+              </button>
+              <button class="chat-btn show-chat invisible" id="show-chat" aria-label="Show chat">
+                <i class="far fa-comment-alt icon-chat" aria-hidden="true"></i>
+              </button>
+              <button class="chat-btn collapse-video invisible" id="collapse-video" aria-label="Hide video and show chat">
+                <i class="far fa-comment-alt icon-chat" aria-hidden="true"></i>
+              </button>
               <div class="video-container invisible" id="video-container">
                 <div id="expand-video" class="expand-video">
                   <div id="peers"></div>
@@ -143,12 +143,12 @@
           </div>
         </div>
       </div>
-    </div>
+    </main>
 
-    <div id="sidebarnav" class="sidenav">
+    <aside id="sidebarnav" class="sidenav" aria-label="Settings">
       <div class="sidenav-header">
         <h2>Settings</h2>
-        <a class="closebtn" id="clodeside"><i class="fas fa-times" aria-hidden="true"></i></a>
+        <button class="closebtn" id="closeside" aria-label="Close settings"><i class="fas fa-times" aria-hidden="true"></i></button>
       </div>
       <div class="sidenav-content" id="optionsdiv">
         <div id="profile" class="profile invisible">
@@ -256,34 +256,36 @@
           </form>
         </fieldset>
       </div>
-    </div>
+    </aside>
 
     <div id="videocontrols-template" class="invisible">
       <div class="video-controls vc-overlay">
         <div class="controls-button controls-left">
-          <span class="video-play" title="Play video">
-            <i class="fas fa-play"></i>
-          </span>
-          <span class="volume" title="Volume">
-            <i class="fas fa-volume-up volume-mute" aria-hidden="true"></i>
-            <input class="volume-slider" type="range" max="100" value="100" min="0" step="5" >
+          <button class="video-play" aria-label="Play video">
+            <i class="fas fa-play" aria-hidden="true"></i>
+          </button>
+          <span class="volume">
+            <button class="volume-mute" aria-label="Mute volume">
+              <i class="fas fa-volume-up" aria-hidden="true"></i>
+            </button>
+            <input class="volume-slider" type="range" max="100" value="100" min="0" step="5" aria-label="Volume">
           </span>
         </div>
         <div class="controls-button controls-right">
-          <span class="pip" title="Picture In Picture">
+          <button class="pip" aria-label="Picture in picture">
             <i class="far fa-clone" aria-hidden="true"></i>
-          </span>
-          <span class="fullscreen" title="Fullscreen">
+          </button>
+          <button class="fullscreen" aria-label="Fullscreen">
             <i class="fas fa-expand" aria-hidden="true"></i>
-          </span>
+          </button>
         </div>
       </div>
     </div>
     <div id="topvideocontrols-template" class="invisible">
       <div class="top-video-controls">
         <div class="controls-button controls-right">
-          <span class="close-icon video-stop" title="Stop video">
-          </span>
+          <button class="close-icon video-stop" aria-label="Stop video">
+          </button>
         </div>
       </div>
     </div>

--- a/static/galene.html
+++ b/static/galene.html
@@ -37,12 +37,12 @@
 
               <ul class="nav-menu">
                 <li>
-                  <button id="presentbutton" class="invisible btn btn-success">
+                  <button id="presentbutton" class="invisible btn btn-success" aria-label="Enable camera and microphone">
                     <i class="fas fa-play" aria-hidden="true"></i><span class="nav-text"> Enable</span>
                   </button>
                 </li>
                 <li>
-                  <button id="unpresentbutton" class="invisible btn btn-cancel">
+                  <button id="unpresentbutton" class="invisible btn btn-cancel" aria-label="Disable camera and microphone">
                     <i class="fas fa-stop" aria-hidden="true"></i><span class="nav-text"> Disable</span>
                   </button>
                 </li>
@@ -77,7 +77,7 @@
                   <div id="chat-announcements" aria-live="polite" aria-atomic="true" class="sr-only"></div>
                   <div class="reply">
                     <form id="inputform">
-                      <textarea id="input" class="form-reply"></textarea>
+                      <textarea id="input" class="form-reply" aria-label="Message or /command"></textarea>
                       <input id="inputbutton" type="submit" value="&#10148;" class="btn btn-default" aria-label="Send message"/>
                     </form>
                   </div>

--- a/static/galene.js
+++ b/static/galene.js
@@ -4749,15 +4749,17 @@ document.addEventListener('keydown', function(e) {
             announcement.textContent = isRaised ? 'Hand lowered' : 'Hand raised';
         }
 
-        // Focus on user's name button in the user list
-        let userButton = document.getElementById('user-' + serverConnection.id);
-        if(userButton) {
-            userButton.focus();
-        }
+        // Focus on user's name button in the user list (delayed to ensure announcement is read)
+        setTimeout(function() {
+            let userButton = document.getElementById('user-' + serverConnection.id);
+            if(userButton) {
+                userButton.focus();
+            }
+        }, 100);
     }
 
-    // Control+Shift+C - Expand or collapse chat
-    if(e.ctrlKey && e.shiftKey && e.key === 'C') {
+    // Control+Alt+C - Expand or collapse chat
+    if(e.ctrlKey && e.altKey && e.key === 'c') {
         e.preventDefault();
 
         let leftPanel = document.getElementById('left');
@@ -4779,10 +4781,12 @@ document.addEventListener('keydown', function(e) {
                 announcement.textContent = 'Chat collapsed';
             }
 
-            // Focus the show-chat button
-            if(showChatButton) {
-                showChatButton.focus();
-            }
+            // Focus the show-chat button (delayed to ensure announcement is read)
+            setTimeout(function() {
+                if(showChatButton) {
+                    showChatButton.focus();
+                }
+            }, 100);
         } else {
             // Expand chat
             setVisibility('left', true);
@@ -4795,11 +4799,43 @@ document.addEventListener('keydown', function(e) {
                 announcement.textContent = 'Chat expanded';
             }
 
-            // Focus the close-chat button
-            if(closeChatButton) {
-                closeChatButton.focus();
-            }
+            // Focus the close-chat button (delayed to ensure announcement is read)
+            setTimeout(function() {
+                if(closeChatButton) {
+                    closeChatButton.focus();
+                }
+            }, 100);
         }
+    }
+
+    // Control+Alt+T - Mute or unmute microphone
+    if(e.ctrlKey && e.altKey && e.key === 't') {
+        e.preventDefault();
+        let muteButton = document.getElementById('mutebutton');
+        if(!muteButton) {
+            return;
+        }
+
+        let localMute = getSettings().localMute;
+        if (localMute && !findUpMedia('camera')) {
+            displayMessage('Please use Enable to enable your camera or microphone.');
+            return;
+        }
+
+        // Toggle mute state
+        localMute = !localMute;
+        setLocalMute(localMute, true);
+
+        // Announce the action
+        let announcement = document.getElementById('chat-announcements');
+        if(announcement) {
+            announcement.textContent = localMute ? 'Microphone muted' : 'Microphone unmuted';
+        }
+
+        // Focus the mute button (delayed to ensure announcement is read)
+        setTimeout(function() {
+            muteButton.focus();
+        }, 100);
     }
 });
 

--- a/static/galene.js
+++ b/static/galene.js
@@ -4724,4 +4724,83 @@ async function start() {
     setViewportHeight();
 }
 
+// Global keyboard shortcuts
+document.addEventListener('keydown', function(e) {
+    // Control+Alt+H - Raise or lower hand
+    if(e.ctrlKey && e.altKey && e.key === 'h') {
+        e.preventDefault();
+        if(!serverConnection || !serverConnection.id) {
+            return;
+        }
+
+        let mydata = serverConnection.users[serverConnection.id].data;
+        let isRaised = mydata['raisehand'];
+
+        // Toggle hand state
+        serverConnection.userAction(
+            'setdata',
+            serverConnection.id,
+            {'raisehand': isRaised ? null : true}
+        );
+
+        // Announce the action
+        let announcement = document.getElementById('chat-announcements');
+        if(announcement) {
+            announcement.textContent = isRaised ? 'Hand lowered' : 'Hand raised';
+        }
+
+        // Focus on user's name button in the user list
+        let userButton = document.getElementById('user-' + serverConnection.id);
+        if(userButton) {
+            userButton.focus();
+        }
+    }
+
+    // Control+Shift+C - Expand or collapse chat
+    if(e.ctrlKey && e.shiftKey && e.key === 'C') {
+        e.preventDefault();
+
+        let leftPanel = document.getElementById('left');
+        let showChatButton = document.getElementById('show-chat');
+        let closeChatButton = document.getElementById('close-chat');
+
+        // Check if chat is currently visible
+        let isChatVisible = leftPanel && leftPanel.style.display !== 'none';
+
+        if(isChatVisible) {
+            // Collapse chat
+            setVisibility('left', false);
+            setVisibility('show-chat', true);
+            resizePeers();
+
+            // Announce the action
+            let announcement = document.getElementById('chat-announcements');
+            if(announcement) {
+                announcement.textContent = 'Chat collapsed';
+            }
+
+            // Focus the show-chat button
+            if(showChatButton) {
+                showChatButton.focus();
+            }
+        } else {
+            // Expand chat
+            setVisibility('left', true);
+            setVisibility('show-chat', false);
+            resizePeers();
+
+            // Announce the action
+            let announcement = document.getElementById('chat-announcements');
+            if(announcement) {
+                announcement.textContent = 'Chat expanded';
+            }
+
+            // Focus the close-chat button
+            if(closeChatButton) {
+                closeChatButton.focus();
+            }
+        }
+    }
+});
+
 start();

--- a/static/galene.js
+++ b/static/galene.js
@@ -2577,7 +2577,11 @@ function makeContextualMenuAccessible(menuElement) {
             menuItems[currentIndex].focus();
         } else if(e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            menuItems[currentIndex].click();
+            // Click the parent li element which has the actual click handler
+            let parentLi = menuItems[currentIndex].parentElement;
+            if(parentLi) {
+                parentLi.click();
+            }
         }
     });
 }

--- a/static/galene.js
+++ b/static/galene.js
@@ -2609,12 +2609,23 @@ function addUser(id, userinfo) {
     let user = document.createElement('div');
     user.id = 'user-' + id;
     user.classList.add("user-p");
+    user.setAttribute('role', 'button');
+    user.setAttribute('tabindex', '0');
     setUserStatus(id, user, userinfo);
     user.addEventListener('click', function(e) {
         let elt = e.target;
         if(!elt || !(elt instanceof HTMLElement))
             throw new Error("Couldn't find user div");
         userMenu(elt);
+    });
+    user.addEventListener('keydown', function(e) {
+        if(e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            let elt = e.target;
+            if(!elt || !(elt instanceof HTMLElement))
+                throw new Error("Couldn't find user div");
+            userMenu(elt);
+        }
     });
 
     let us = div.children;
@@ -3663,6 +3674,24 @@ commands.unlock = {
     }
 };
 
+commands.raisehand = {
+    description: 'raise your hand',
+    f: (c, r) => {
+        if(!serverConnection || !serverConnection.id)
+            throw new Error('Not connected');
+        serverConnection.userAction('setdata', serverConnection.id, {'raisehand': true});
+    }
+};
+
+commands.unraisehand = {
+    description: 'lower your hand',
+    f: (c, r) => {
+        if(!serverConnection || !serverConnection.id)
+            throw new Error('Not connected');
+        serverConnection.userAction('setdata', serverConnection.id, {'raisehand': null});
+    }
+};
+
 commands.record = {
     predicate: recordingPredicate,
     description: 'start recording',
@@ -4319,6 +4348,30 @@ function chatResizer(e) {
 
 document.getElementById('resizer').addEventListener('mousedown', chatResizer, false);
 
+// Add keyboard support for chat resizer
+document.getElementById('resizer').addEventListener('keydown', function(e) {
+    if(e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        e.preventDefault();
+        let full_width = document.getElementById("mainrow").offsetWidth;
+        let left = document.getElementById("left");
+        let right = document.getElementById("right");
+        let current_width = left.offsetWidth;
+        let step = 20; // pixels per keypress
+
+        let new_width = e.key === 'ArrowLeft' ? current_width - step : current_width + step;
+        let left_percent = new_width * 100 / full_width;
+
+        // set min chat width to 300px
+        let min_left_width = 300 * 100 / full_width;
+        if (left_percent < min_left_width) {
+            return;
+        }
+
+        left.style.flex = left_percent.toString();
+        right.style.flex = (100 - left_percent).toString();
+    }
+}, false);
+
 /**
  * @param {unknown} message
  * @param {string} [level]
@@ -4405,6 +4458,14 @@ document.getElementById('sidebarCollapse').onclick = function(e) {
     document.getElementById("mainrow").classList.toggle("full-width-active");
 };
 
+document.getElementById('sidebarCollapse').onkeydown = function(e) {
+    if(e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        document.getElementById("left-sidebar").classList.toggle("active");
+        document.getElementById("mainrow").classList.toggle("full-width-active");
+    }
+};
+
 document.getElementById('openside').onclick = function(e) {
       e.preventDefault();
       let sidewidth = document.getElementById("sidebarnav").style.width;
@@ -4416,10 +4477,30 @@ document.getElementById('openside').onclick = function(e) {
       }
 };
 
+document.getElementById('openside').onkeydown = function(e) {
+      if(e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          let sidewidth = document.getElementById("sidebarnav").style.width;
+          if (sidewidth !== "0px" && sidewidth !== "") {
+              closeNav();
+              return;
+          } else {
+              openNav();
+          }
+      }
+};
+
 
 document.getElementById('closeside').onclick = function(e) {
     e.preventDefault();
     closeNav();
+};
+
+document.getElementById('closeside').onkeydown = function(e) {
+    if(e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        closeNav();
+    }
 };
 
 document.getElementById('collapse-video').onclick = function(e) {
@@ -4429,11 +4510,29 @@ document.getElementById('collapse-video').onclick = function(e) {
     hideVideo(true);
 };
 
+document.getElementById('collapse-video').onkeydown = function(e) {
+    if(e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        setVisibility('collapse-video', false);
+        setVisibility('show-video', true);
+        hideVideo(true);
+    }
+};
+
 document.getElementById('show-video').onclick = function(e) {
     e.preventDefault();
     setVisibility('video-container', true);
     setVisibility('collapse-video', true);
     setVisibility('show-video', false);
+};
+
+document.getElementById('show-video').onkeydown = function(e) {
+    if(e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        setVisibility('video-container', true);
+        setVisibility('collapse-video', true);
+        setVisibility('show-video', false);
+    }
 };
 
 document.getElementById('close-chat').onclick = function(e) {
@@ -4443,11 +4542,29 @@ document.getElementById('close-chat').onclick = function(e) {
     resizePeers();
 };
 
+document.getElementById('close-chat').onkeydown = function(e) {
+    if(e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        setVisibility('left', false);
+        setVisibility('show-chat', true);
+        resizePeers();
+    }
+};
+
 document.getElementById('show-chat').onclick = function(e) {
     e.preventDefault();
     setVisibility('left', true);
     setVisibility('show-chat', false);
     resizePeers();
+};
+
+document.getElementById('show-chat').onkeydown = function(e) {
+    if(e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        setVisibility('left', true);
+        setVisibility('show-chat', false);
+        resizePeers();
+    }
 };
 
 async function serverConnect() {

--- a/static/galene.js
+++ b/static/galene.js
@@ -4344,7 +4344,7 @@ function displayError(message, level) {
     /** @ts-ignore */
     Toastify({
         text: message,
-        duration: 4000,
+        duration: 8000,  // Increased from 4000 for screen reader users
         close: true,
         position: position,
         gravity: gravity,
@@ -4417,7 +4417,7 @@ document.getElementById('openside').onclick = function(e) {
 };
 
 
-document.getElementById('clodeside').onclick = function(e) {
+document.getElementById('closeside').onclick = function(e) {
     e.preventDefault();
     closeNav();
 };

--- a/static/galene.js
+++ b/static/galene.js
@@ -3441,7 +3441,7 @@ function addToChatbox(id, peerId, dest, nick, time, privileged, history, kind, m
         }
 
         if(doHeader) {
-            let header = document.createElement('p');
+            let header = document.createElement('h3');
             let user = document.createElement('span');
             let u = dest && serverConnection.users[dest];
             let name = (u && u.username);
@@ -4523,15 +4523,23 @@ function closeNav() {
 }
 
 document.getElementById('sidebarCollapse').onclick = function(e) {
-    document.getElementById("left-sidebar").classList.toggle("active");
+    let sidebar = document.getElementById("left-sidebar");
+    sidebar.classList.toggle("active");
     document.getElementById("mainrow").classList.toggle("full-width-active");
+    // Update aria-expanded to reflect the state
+    let isCollapsed = sidebar.classList.contains("active");
+    e.currentTarget.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
 };
 
 document.getElementById('sidebarCollapse').onkeydown = function(e) {
     if(e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
-        document.getElementById("left-sidebar").classList.toggle("active");
+        let sidebar = document.getElementById("left-sidebar");
+        sidebar.classList.toggle("active");
         document.getElementById("mainrow").classList.toggle("full-width-active");
+        // Update aria-expanded to reflect the state
+        let isCollapsed = sidebar.classList.contains("active");
+        e.currentTarget.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
     }
 };
 

--- a/static/galene.js
+++ b/static/galene.js
@@ -2536,6 +2536,53 @@ document.getElementById('invite-dialog').onclose = function(e) {
 };
 
 /**
+ * Adds keyboard navigation to Contextual menu
+ * @param {HTMLElement} menuElement
+ */
+function makeContextualMenuAccessible(menuElement) {
+    // Find all menu items
+    let menuItems = menuElement.querySelectorAll('.contextualMenuItem:not(.disabled)');
+    if(menuItems.length === 0) return;
+
+    let currentIndex = 0;
+
+    // Make menu items focusable and add ARIA
+    menuItems.forEach((item, index) => {
+        item.setAttribute('role', 'menuitem');
+        item.setAttribute('tabindex', index === 0 ? '0' : '-1');
+    });
+
+    // Focus first item
+    menuItems[0].focus();
+
+    // Add keyboard navigation
+    menuElement.addEventListener('keydown', function(e) {
+        if(e.key === 'Escape') {
+            e.preventDefault();
+            contextualCore.CloseMenu();
+            return;
+        }
+
+        if(e.key === 'ArrowDown') {
+            e.preventDefault();
+            menuItems[currentIndex].setAttribute('tabindex', '-1');
+            currentIndex = (currentIndex + 1) % menuItems.length;
+            menuItems[currentIndex].setAttribute('tabindex', '0');
+            menuItems[currentIndex].focus();
+        } else if(e.key === 'ArrowUp') {
+            e.preventDefault();
+            menuItems[currentIndex].setAttribute('tabindex', '-1');
+            currentIndex = currentIndex === 0 ? menuItems.length - 1 : currentIndex - 1;
+            menuItems[currentIndex].setAttribute('tabindex', '0');
+            menuItems[currentIndex].focus();
+        } else if(e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            menuItems[currentIndex].click();
+        }
+    });
+}
+
+/**
  * @param {HTMLElement} elt
  */
 function userMenu(elt) {
@@ -2598,6 +2645,15 @@ function userMenu(elt) {
     new Contextual({
         items: items,
     });
+
+    // Add keyboard navigation after menu is created
+    setTimeout(() => {
+        let menu = document.querySelector('.contextualMenu');
+        if(menu) {
+            menu.setAttribute('role', 'menu');
+            makeContextualMenuAccessible(menu);
+        }
+    }, 0);
 }
 
 /**
@@ -3482,6 +3538,15 @@ function chatMessageMenu(elt) {
     new Contextual({
         items: items,
     });
+
+    // Add keyboard navigation after menu is created
+    setTimeout(() => {
+        let menu = document.querySelector('.contextualMenu');
+        if(menu) {
+            menu.setAttribute('role', 'menu');
+            makeContextualMenuAccessible(menu);
+        }
+    }, 0);
 }
 
 /**

--- a/static/galene.js
+++ b/static/galene.js
@@ -626,10 +626,14 @@ function setLocalMute(mute, reflect) {
         icon.classList.add('fa-microphone-slash');
         icon.classList.remove('fa-microphone');
         button.classList.add('muted');
+        button.setAttribute('aria-pressed', 'true');
+        button.setAttribute('aria-label', 'Unmute microphone');
     } else {
         icon.classList.remove('fa-microphone-slash');
         icon.classList.add('fa-microphone');
         button.classList.remove('muted');
+        button.setAttribute('aria-pressed', 'false');
+        button.setAttribute('aria-label', 'Mute microphone');
     }
     if(reflect)
         updateSettings({localMute: mute});
@@ -2060,6 +2064,10 @@ async function setMedia(c, mirror, video) {
         peersdiv.appendChild(div);
     }
 
+    // Add aria-label to identify video stream owner
+    let username = c.username || 'Participant';
+    div.setAttribute('aria-label', `Video stream from ${username}`);
+
     showHideMedia(c, div)
 
     let media = /** @type {HTMLVideoElement} */
@@ -2077,6 +2085,9 @@ async function setMedia(c, mirror, video) {
         media.autoplay = true;
         media.playsInline = true;
         media.id = 'media-' + c.localId;
+        // Add aria-label for screen readers
+        let username = c.username || 'Participant';
+        media.setAttribute('aria-label', `Video from ${username}`);
         div.appendChild(media);
         addCustomControls(media, div, c, !!video);
     }
@@ -2653,11 +2664,24 @@ function changeUser(id, userinfo) {
  * @param {user} userinfo
  */
 function setUserStatus(id, elt, userinfo) {
-    elt.textContent = userinfo.username ? userinfo.username : '(anon)';
-    if(userinfo.data.raisehand)
+    let username = userinfo.username ? userinfo.username : '(anon)';
+    elt.textContent = username;
+
+    let wasRaised = elt.classList.contains('user-status-raisehand');
+    if(userinfo.data.raisehand) {
         elt.classList.add('user-status-raisehand');
-    else
+        elt.setAttribute('aria-label', `${username} (hand raised)`);
+        // Announce when hand is newly raised (not on initial load)
+        if(!wasRaised && id !== (serverConnection && serverConnection.id)) {
+            let announcement = document.getElementById('chat-announcements');
+            if(announcement) {
+                announcement.textContent = `${username} raised their hand`;
+            }
+        }
+    } else {
         elt.classList.remove('user-status-raisehand');
+        elt.setAttribute('aria-label', username);
+    }
 
     let microphone=false, camera = false;
     for(let label in userinfo.streams) {
@@ -2668,6 +2692,17 @@ function setUserStatus(id, elt, userinfo) {
                 camera = true;
         }
     }
+
+    // Build descriptive aria-label with media status
+    let statusParts = [username];
+    if(userinfo.data.raisehand)
+        statusParts.push('hand raised');
+    if(camera)
+        statusParts.push('camera on');
+    if(microphone)
+        statusParts.push('microphone on');
+    elt.setAttribute('aria-label', statusParts.join(', '));
+
     if(camera) {
         elt.classList.remove('user-status-microphone');
         elt.classList.add('user-status-camera');
@@ -3382,6 +3417,15 @@ function addToChatbox(id, peerId, dest, nick, time, privileged, history, kind, m
     box.appendChild(row);
     if(box.scrollHeight > box.clientHeight) {
         box.scrollTop = box.scrollHeight - box.clientHeight;
+    }
+
+    // Announce new messages to screen readers (but not history)
+    if(!history) {
+        let announcement = document.getElementById('chat-announcements');
+        if(announcement) {
+            let messageText = typeof message === 'string' ? message : body.textContent;
+            announcement.textContent = nick ? `${nick}: ${messageText}` : messageText;
+        }
     }
 
     return;

--- a/static/galene.js
+++ b/static/galene.js
@@ -3669,7 +3669,11 @@ commands.help = {
                 continue;
             cs.push(`/${cmd}${c.parameters?' ' + c.parameters:''}: ${c.description}`);
         }
-        localMessage(cs.sort().join('\n'));
+        let shortcuts = '\n\nKeyboard shortcuts:\n' +
+            'Control+Alt+H: Raise or lower hand\n' +
+            'Control+Alt+C: Expand or collapse chat\n' +
+            'Control+Alt+T: Mute or unmute microphone';
+        localMessage(cs.sort().join('\n') + shortcuts);
     }
 };
 
@@ -4727,7 +4731,7 @@ async function start() {
 // Global keyboard shortcuts
 document.addEventListener('keydown', function(e) {
     // Control+Alt+H - Raise or lower hand
-    if(e.ctrlKey && e.altKey && e.key === 'h') {
+    if(e.ctrlKey && e.altKey && e.key.toLowerCase() === 'h') {
         e.preventDefault();
         if(!serverConnection || !serverConnection.id) {
             return;
@@ -4759,7 +4763,7 @@ document.addEventListener('keydown', function(e) {
     }
 
     // Control+Alt+C - Expand or collapse chat
-    if(e.ctrlKey && e.altKey && e.key === 'c') {
+    if(e.ctrlKey && e.altKey && e.key.toLowerCase() === 'c') {
         e.preventDefault();
 
         let leftPanel = document.getElementById('left');
@@ -4809,7 +4813,7 @@ document.addEventListener('keydown', function(e) {
     }
 
     // Control+Alt+T - Mute or unmute microphone
-    if(e.ctrlKey && e.altKey && e.key === 't') {
+    if(e.ctrlKey && e.altKey && e.key.toLowerCase() === 't') {
         e.preventDefault();
         let muteButton = document.getElementById('mutebutton');
         if(!muteButton) {


### PR DESCRIPTION
This pull request makes Galene significantly more accessible for screen reader users, especially people using Orca on Linux or NVDA on Windows.

The changes focus on making the web client easier to understand and operate without relying on visual layout alone. They add or improve accessible labels, headings, keyboard interaction, focus behavior, and announcements so that common meeting tasks are reachable with a screen reader and keyboard.

Summary:

- Add accessible names and state updates for key meeting controls, including microphone mute/unmute, video controls, chat controls, and user entries.
- Improve keyboard access for the user list and context menus, including menu navigation and activation from the keyboard.
- Add screen-reader-friendly chat structure and live announcements for important updates such as new chat messages and raised hands.
- Improve user status announcements by including hand-raised, camera, and microphone state in accessible labels.
- Add keyboard shortcuts for common meeting actions and document them in `/help`.
- Fix radio button grouping and other form/control semantics that affected assistive technology.
- Fix a logout control that had a label but was not naturally keyboard-focusable.

This also includes a small typo fix in an error message found while updating against current `master`.

Verification:

- Static accessibility audit over first-party HTML controls: passed.
- `node --check static/galene.js`: passed.
- `go test ./...`: passed.
