### PR TITLE
Added -headless argument to start the server without serving the frontend

### DIFF
--- a/galene.go
+++ b/galene.go
@@ -51,6 +51,7 @@ func main() {
 		"require use of TURN relays for all media traffic")
 	flag.StringVar(&turnserver.Address, "turn", "auto",
 		"built-in TURN server `address` (\"\" to disable)")
+	flag.BoolVar(&webserver.NoStatic, "no-static", false, "run without serving the frontend")
 	flag.Parse()
 
 	if udpRange != "" {

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -33,9 +33,13 @@ var StaticRoot string
 
 var Insecure bool
 
+var NoStatic bool
+
 func Serve(address string, dataDir string) error {
-	http.Handle("/", &fileHandler{http.Dir(StaticRoot)})
-	http.HandleFunc("/group/", groupHandler)
+	if !NoStatic {
+		http.Handle("/", &fileHandler{http.Dir(StaticRoot)})
+		http.HandleFunc("/group/", groupHandler)
+	}
 	http.HandleFunc("/recordings",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r,


### PR DESCRIPTION
Added -headless argument to start the server without serving the frontend, and completed the galene-protocol.md to mention it where I thought it would be useful. Feel free to ask me to document the change somewhere else if necessary !